### PR TITLE
Update API endpoints to v2 - BREAKING CHANGE

### DIFF
--- a/dotnet-petclinic-payment/PetClinic.PaymentService/Program.cs
+++ b/dotnet-petclinic-payment/PetClinic.PaymentService/Program.cs
@@ -41,7 +41,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHealthChecks("/healthz");
 
-app.MapGet("/owners/{ownerId:int}/pets/{petId:int}/payments",
+app.MapGet("/api/v2/owners/{ownerId:int}/pets/{petId:int}/payments",
     async (
         int ownerId,
         int petId,
@@ -68,7 +68,7 @@ app.MapGet("/owners/{ownerId:int}/pets/{petId:int}/payments",
     }
 );
 
-app.MapGet("/owners/{ownerId:int}/pets/{petId:int}/payments/{paymentId}",
+app.MapGet("/api/v2/owners/{ownerId:int}/pets/{petId:int}/payments/{paymentId}",
     async (
         int ownerId,
         int petId,
@@ -105,7 +105,7 @@ app.MapGet("/owners/{ownerId:int}/pets/{petId:int}/payments/{paymentId}",
     }
 );
 
-app.MapPost("/owners/{ownerId:int}/pets/{petId:int}/payments/",
+app.MapPost("/api/v2/owners/{ownerId:int}/pets/{petId:int}/payments/",
     async (
         int ownerId,
         int petId,


### PR DESCRIPTION
## Breaking Change: Payment Service API v2

This PR updates the payment service endpoints from v1 to v2:

### Changes:
- `/owners/{ownerId}/pets/{petId}/payments` → `/api/v2/owners/{ownerId}/pets/{petId}/payments`
- `/owners/{ownerId}/pets/{petId}/payments/{paymentId}` → `/api/v2/owners/{ownerId}/pets/{petId}/payments/{paymentId}`
- `/owners/{ownerId}/pets/{petId}/payments/` → `/api/v2/owners/{ownerId}/pets/{petId}/payments/`

### ⚠️ Deployment Dependencies:
This PR has **breaking changes** that require:
1. API Gateway (PaymentClient.java) must be updated to use v2 endpoints **BEFORE** this PR is deployed
2. Any frontend components calling payment endpoints directly must be updated
3. Integration tests must be updated to use new endpoints

### Files Changed:
- `dotnet-petclinic-payment/PetClinic.PaymentService/Program.cs`

**This PR should be blocked until consumer services are updated to use the new API endpoints.**