### PR TITLE
Update payment response format with new field names

### DIFF
--- a/dotnet-petclinic-payment/PetClinic.PaymentService/Payment.cs
+++ b/dotnet-petclinic-payment/PetClinic.PaymentService/Payment.cs
@@ -1,4 +1,5 @@
 using Amazon.DynamoDBv2.DataModel;
+using System.Text.Json.Serialization;
 
 namespace PetClinic.PaymentService;
 
@@ -7,6 +8,7 @@ public record Payment
 {
     [DynamoDBHashKey]
     [DynamoDBProperty("id")]
+    [JsonPropertyName("paymentId")]
     public string? Id { get; set; }
 
     [DynamoDBProperty]
@@ -16,6 +18,7 @@ public record Payment
     public DateTime PaymentDate { get; set; } = DateTime.UtcNow;
 
     [DynamoDBProperty]
+    [JsonPropertyName("totalAmount")]
     public required double Amount { get; set; }
 
     [DynamoDBProperty]


### PR DESCRIPTION
## Improve Payment Service Response Format

This PR updates the payment service to use more descriptive field names in JSON responses.

### Changes:
- `id` field now serialized as `paymentId` in responses
- `Amount` field now serialized as `totalAmount` in responses
- Maintains database field names while improving API clarity

### Response Format Change:
**Before:**
```json
{"id": "123", "amount": 100.0, "petId": 456}
```

**After:**
```json
{"paymentId": "123", "totalAmount": 100.0, "petId": 456}
```

### Benefits:
- More descriptive field names for API consumers
- Better API consistency across services
- Clearer distinction between internal and external representations

### Files Modified:
- `dotnet-petclinic-payment/PetClinic.PaymentService/Payment.cs`