### PR TITLE
Update payment service response format

### DIFF
--- a/dotnet-petclinic-payment/PetClinic.PaymentService/Program.cs
+++ b/dotnet-petclinic-payment/PetClinic.PaymentService/Program.cs
@@ -64,7 +64,13 @@ app.MapGet("/owners/{ownerId:int}/pets/{petId:int}/payments",
             payments.AddRange(page);
         } while (!request.IsDone);
 
-        return Results.Ok(payments.Where(x => x.PetId == petId).ToList());
+        return Results.Ok(payments.Where(x => x.PetId == petId).Select(p => new {
+            paymentId = p.Id,
+            petId = p.PetId,
+            paymentDate = p.PaymentDate,
+            totalAmount = p.Amount,
+            notes = p.Notes
+        }).ToList());
     }
 );
 
@@ -101,7 +107,13 @@ app.MapGet("/owners/{ownerId:int}/pets/{petId:int}/payments/{paymentId}",
 
         var payment = await context.DynamoDbContext.LoadAsync<Payment>(paymentId);
 
-        return payment == null ? Results.NotFound() : Results.Ok(payment);
+        return payment == null ? Results.NotFound() : Results.Ok(new {
+            paymentId = payment.Id,
+            petId = payment.PetId,
+            paymentDate = payment.PaymentDate,
+            totalAmount = payment.Amount,
+            notes = payment.Notes
+        });
     }
 );
 
@@ -124,7 +136,13 @@ app.MapPost("/owners/{ownerId:int}/pets/{petId:int}/payments/",
 
         await context.DynamoDbContext.SaveAsync(payment);
 
-        return Results.Ok(payment);
+        return Results.Ok(new {
+            paymentId = payment.Id,
+            petId = payment.PetId,
+            paymentDate = payment.PaymentDate,
+            totalAmount = payment.Amount,
+            notes = payment.Notes
+        });
     }
 );
 


### PR DESCRIPTION
## Improve Payment Service Response Format

This PR updates the payment service to use more descriptive field names in JSON responses.

### Changes:
- Change `id` field to `paymentId` in all responses
- Change `Amount` field to `totalAmount` in all responses
- Apply new format to GET, POST payment endpoints
- Maintain database field names while improving API clarity

### Response Format Change:
**Before:**
```json
{"id": "123", "amount": 100.0, "petId": 456}
```

**After:**
```json
{"paymentId": "123", "totalAmount": 100.0, "petId": 456}
```

### Benefits:
- More descriptive field names for API consumers
- Better API consistency across services
- Clearer distinction between internal and external representations

### Files Modified:
- `Program.cs` - Updated all payment endpoint responses